### PR TITLE
fill the `description` field in the package's `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rxjs.node",
   "version": "0.2.0",
-  "description": "",
+  "description": "Tooling to adapt Node.js core functionality into RxJS",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Currently the `description` field in the package's `package.json` is empty and thus the subheading of https://www.npmjs.com/package/rxjs.node does not look very pleasant.

This patch contains a fix for it.

(It also introduces a linebreak at the end of the file because that's how GitHub's online editor does its job.)